### PR TITLE
Add `setGasLimit` option to useSmartContractTransaction (CU-22gt4y7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -448,6 +448,29 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.1.tgz",
       "integrity": "sha512-NXKvBVUzIbs6ylBwmOwHFkZS2EXCcjnqr8ZCRNaXBkHAf+3mn/rPcJxwrzuc6movh8fxQAsUUfYklJ/EG+hZqQ=="
     },
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
+      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
     "@zerollup/ts-helpers": {
       "version": "1.7.18",
       "resolved": "https://registry.npmjs.org/@zerollup/ts-helpers/-/ts-helpers-1.7.18.tgz",
@@ -542,6 +565,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
+    "csstype": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
+      "dev": true
     },
     "detect-node": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,7 @@
     "ttypescript": "^1.5.13",
     "typescript": "^4.3.5"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@types/react": "^17.0.38"
+  }
 }

--- a/src/hooks/useSmartContractTransaction/useSmartContractTransaction.ts
+++ b/src/hooks/useSmartContractTransaction/useSmartContractTransaction.ts
@@ -99,7 +99,7 @@ export function useSmartContractTransaction<
 
         const lastItem = args[args.length - 1];
         if (isOverridesObject(lastItem)) {
-          const argsWithoutOverrides = args.slice(0, args.length);
+          const argsWithoutOverrides = args.slice(0, args.length - 1);
           const newOverrides: Overrides = { ...lastItem, gasLimit };
           finalCallArgs = [
             ...argsWithoutOverrides,

--- a/src/hooks/useSmartContractTransaction/useSmartContractTransaction.ts
+++ b/src/hooks/useSmartContractTransaction/useSmartContractTransaction.ts
@@ -185,5 +185,5 @@ async function fetchGasEstimate<
       EstimateGasMethodName<TContract>,
       EstimateGasContractCall<TContract, TMethodName>
     >
-  )[methodName](args);
+  )[methodName](...args);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,14 @@ export type ContractCall<
 > = TContract[TMethodName];
 
 /**
+ * Gets a type for a estimateGas call
+ */
+export type EstimateGasContractCall<
+  TContract extends Contract,
+  TMethodName extends ContractMethodName<TContract>
+> = TContract["estimateGas"][TMethodName];
+
+/**
  * Gets a type for a contract query call
  */
 export type ContractFilterCall<
@@ -34,12 +42,19 @@ export type ContractFunctionCall<
   TMethodName extends ContractMethodName<TContract>
 > = TContract["functions"][TMethodName];
 
+export type EstimateGasMethodName<TContract extends Contract> =
+  keyof TContract["estimateGas"];
+
 /**
  * Gets a type for the methods available on a given contract
  */
 export type ContractMethodName<TContract extends Contract> =
   keyof TContract["functions"];
 
+export type EstimateGasMethodArgs<
+  TContract extends Contract,
+  TMethodName extends EstimateGasMethodName<TContract>
+> = Parameters<EstimateGasContractCall<TContract, TMethodName>>;
 /**
  * Gets a type for the filters available on a given contract
  */

--- a/src/utils/isOverridesObject.ts
+++ b/src/utils/isOverridesObject.ts
@@ -1,0 +1,17 @@
+import { Overrides } from "ethers";
+import isPlainObject from "lodash.isplainobject";
+
+export function isOverridesObject(obj: any): obj is Overrides {
+  if (isPlainObject(obj)) {
+    const overrides = obj as Overrides;
+    if (
+      "gasPrice" in overrides ||
+      "gasLimit" in overrides ||
+      "value" in overrides ||
+      "nonce" in overrides
+    ) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
One of the tricky things about web3 is setting a good gasLimit for how much you're willing to pay for the tx to go through. Ethereum providers all have an `estimateGas` method to help you ballpark it, but sometimes a tx is complex enough that it cannot accurately guess how much it will cost to run the transaction.

In these scenarios, it makes sense to buffer the provider's estimate by some multiplier or constant amount.

With this API it's very easy to just set a gasLimit override, eg:

```ts
const { mutate: mint } = useSmartContractTransaction(
  mintContract,
  "mint",
  signer, 
  { setGasLimit: (gasEstimate) => gasEstimate * 1.05 }
);

// this mint will be called with 1.05x the estimated gas amount
mint(...);
```